### PR TITLE
Use official gdal.org dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ library.
 
 ## Dependencies [&#x219F;](#contents)
 
+* Java 1.7 or higher (uses java.nio via the nio Clojure wrapper)
 * GDAL 2.0.0 (included)
 
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ library.
 
 ## Dependencies [&#x219F;](#contents)
 
-Currently, only GDAL 2.0.1 support is provided.
+* GDAL 2.0.0 (included)
 
 
 ## Getting Started [&#x219F;](#contents)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 * [About](#about-)
 * [Dependencies](#dependencies-)
-* [Getting Started](#getting-started-)
+* [Usage](#usage-)
 * [License](#license-)
 
 
@@ -30,16 +30,27 @@ library.
 ## Dependencies [&#x219F;](#contents)
 
 * Java 1.7 or higher (uses java.nio via the nio Clojure wrapper)
-* GDAL 2.0.0 (included)
+* Java GDAL 2.0.0 library (included)
+
+The Java library downloaded from Maven still requires that you have GDAL 2.x
+compiled on your system, as it references libraries which GDAL builds.
 
 
-## Getting Started [&#x219F;](#contents)
+## Usage [&#x219F;](#contents)
 
-You must compile GDAL 2.0.1 Java SWIG bindings and add the generated libraries to `LD_LIBRARY_PATH`
-
-Then add clj-gdal a dependency to your lein project:
+Add clj-gdal a dependency to your lein project:
 
 [![Clojars Project](http://clojars.org/clj-gdal/latest-version.svg)](http://clojars.org/clj-gdal)
+
+Then start up the Clojure REPL:
+
+```bash
+$ lein repl
+```
+```clojure
+clj-gdal.core=> (init)
+clj-gdal.core=> (open "LC80280302015112LGN00_B1.TIF")
+```
 
 
 ## License [&#x219F;](#contents)

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.gdal/gdal "2.0.0"]
-                 [nio "1.0.3"]])
+                 [nio "1.0.3"]]
+  :repl-options {:init-ns clj-gdal.core})

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [nio "1.0.3"]
-                 [jmorton/gdal "2.0.1-SNAPSHOT"]])
+                 [org.gdal/gdal "2.0.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject clj-gdal "0.0.1-SNAPSHOT"
+(defproject clj-gdal "0.1.0-SNAPSHOT"
   :description "GDAL for Clojure"
   :url "http://github.com/jmorton/clj-gdal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [nio "1.0.3"]
-                 [org.gdal/gdal "2.0.0"]])
+                 [org.gdal/gdal "2.0.0"]
+                 [nio "1.0.3"]])


### PR DESCRIPTION
This uses the org.gdal/gdal 2.0.0 that already exists in Maven.

Note that it is based upon the add-logo and add-toc-etc branches.
