### PR TITLE
Simplified raster read functions.

### DIFF
--- a/test/clj_gdal/band_test.clj
+++ b/test/clj_gdal/band_test.clj
@@ -82,10 +82,6 @@
         (let [blocks (raster-seq band :xstep 100 :ystep 50)]
           (is (= 200 (count blocks))))))
     (testing "Raster sequence of byte buffer"
-      (let [blocks (raster-byte-buffer-seq band :xstep 500 :ystep 500)]
+      (let [blocks (raster-seq band :xstep 500 :ystep 500)]
         (is (= 4 (count blocks)))
-        (is (every? #(= (type %) java.nio.DirectByteBuffer) blocks))))
-    (testing "Raster vector (getting one block as a vector)"
-      (testing "explicit call for small area"
-        (let [block (raster-vec band :xstart 10 :xstop 20 :ystart 10 :ystop 20)]
-          (is (= 100 (count block))))))))
+        (is (every? #(= (type (:data %)) java.nio.DirectByteBuffer) blocks))))))


### PR DESCRIPTION
I've removed a number of redundant read functions and augmented the return results of the raster-seq function.

Instead of implementing every overloaded version of the read-raster-direct function, I've decided to start with the simple cases first. Passing in buffer parameters requires a lot of upfront configuration. The read-raster-direct now relies on the ReadRaster_Direct implementation that automatically initializes a buffer. Although this will lead to slower performance, it does simplify things for the time being. This dramatically simplifies the raster-seq function and has the added benefit of it now being parallelization friendly as the buffer is no longer shared!
