### PR TITLE
Add gdal lib dirs to Java's usr_path dynamically

### DIFF
--- a/src/gdal/band.clj
+++ b/src/gdal/band.clj
@@ -1,5 +1,6 @@
 (ns gdal.band
-  (:require [nio.core :as nio])
+  (:require [gdal.core]
+            [nio.core :as nio])
   (:import [java.nio ByteBuffer]
            [org.gdal.gdalconst gdalconst]))
 

--- a/src/gdal/dataset.clj
+++ b/src/gdal/dataset.clj
@@ -1,4 +1,5 @@
 (ns gdal.dataset
+  (:require [gdal.core])
   (:import [org.gdal.gdal Dataset]
            [org.gdal.gdalconst gdalconst]
            [java.nio ByteBuffer]

--- a/src/gdal/dev.clj
+++ b/src/gdal/dev.clj
@@ -3,11 +3,12 @@
             [clojure.reflect :as reflect]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.repl :as repl]
-            [gdal.core :as gdal]
             [gdal.band :as band]
             [gdal.dataset :as dataset]
             [gdal.proj :as proj]
-            [gdal.util :refer :all])
+            [gdal.util :refer :all]
+            [gdal.core :as gdal]
+            )
   (:import [java.nio ByteBuffer]
            [org.gdal.gdalconst gdalconst]))
 

--- a/src/gdal/driver.clj
+++ b/src/gdal/driver.clj
@@ -1,4 +1,5 @@
-(ns gdal.driver)
+(ns gdal.driver
+  (:require [gdal.core]))
 
 (defn register
   "Register a driver for use"

--- a/src/gdal/proj.clj
+++ b/src/gdal/proj.clj
@@ -9,7 +9,8 @@
 ;;;; non-standard fields
 ;;;;
 (ns gdal.proj
-  (:require [gdal.util :refer :all])
+  (:require [gdal.core]
+            [gdal.util :refer :all])
   (:import [org.gdal.gdal Dataset]
            [org.gdal.gdalconst gdalconst]
            [java.nio ByteBuffer]

--- a/src/gdal/util.clj
+++ b/src/gdal/util.clj
@@ -1,4 +1,5 @@
-(ns gdal.util)
+(ns gdal.util
+  (:require [gdal.core]))
 
 (defn obj->str
   ([obj]

--- a/test/gdal/band_test.clj
+++ b/test/gdal/band_test.clj
@@ -1,8 +1,8 @@
 (ns gdal.band-test
   (:require [clojure.test :refer :all]
             [nio.core :as nio]
-            [gdal.band :as band]
             [gdal.core :as gdal]
+            [gdal.band :as band]
             [gdal.dataset :as dataset])
   (:import [org.gdal.gdalconst gdalconst]))
 
@@ -119,4 +119,3 @@
     (let [blocks (band/raster-seq *band* :xstep 500 :ystep 500)]
       (is (= 4 (count blocks)))
       (is (every? #(= (type (:data %)) java.nio.DirectByteBuffer) blocks)))))
-

--- a/test/gdal/proj_test.clj
+++ b/test/gdal/proj_test.clj
@@ -1,8 +1,8 @@
 (ns gdal.proj-test
   (:require [clojure.test :refer :all]
             [nio.core :as nio]
-            [gdal.band :as band]
             [gdal.core :as gdal]
+            [gdal.band :as band]
             [gdal.dataset :as dataset]
             [gdal.proj :as proj])
   (:import [org.gdal.gdalconst gdalconst]))


### PR DESCRIPTION
@oubiwann -- I finally figured it out! Update the java.library.path system property directly doesn't do what I thought, the value at startup is cached. Unless of course, we apply SORCERY!
